### PR TITLE
Fixed initial scroll issue

### DIFF
--- a/src/SmoothPicker.js
+++ b/src/SmoothPicker.js
@@ -181,6 +181,10 @@ class SmoothPicker extends Component {
         {...this.props}
         {...snap}
         onLayout={({ nativeEvent: { layout } }) => {
+          this.smoothPicker.scrollToIndex({
+            animated: false,
+            index: this.props.initialScrollToIndex
+          });
           this.widthParent = layout.width;
           this.heightParent = layout.height;
         }}
@@ -239,7 +243,7 @@ class SmoothPicker extends Component {
           }
         }}
         renderItem={this._renderItem}
-        ref={"smoothPicker"}
+        ref={instance => this.smoothPicker = instance}
       />
     );
   }


### PR DESCRIPTION
When passing in an initial scroll value, the picker would break beyond 50. This commit fixes that.